### PR TITLE
urm37: show an example of statically defining mraa resources in a sta…

### DIFF
--- a/src/urm37/urm37.h
+++ b/src/urm37/urm37.h
@@ -81,7 +81,7 @@
  * An example using UART mode
  * @snippet urm37-uart.cxx Interesting
  */
-typedef struct _upm_urm37v4* upm_urm37;;
+typedef struct _upm_urm37v4* upm_urm37;
 
 const void* upm_urm37_get_ft(upm_sensor_t sensor_type);
 
@@ -97,7 +97,8 @@ void* upm_urm37_init_name();
  * @param uart Default UART to use (0 or 1).
  * @param mode analog/uart mode
  */
-void* upm_urm37_init(uint8_t a_pin, uint8_t reset_pin, uint8_t trigger_pin, float a_ref, uint8_t uart, upm_protocol_t mode);
+void* upm_urm37_init(uint8_t a_pin, uint8_t reset_pin, uint8_t trigger_pin,
+                     float a_ref, uint8_t uart, upm_protocol_t mode);
 
 /**
  * URM37 sensor close function


### PR DESCRIPTION
…ndard way

**This should not be merged.**  ignore the changes in urm37.h.  All the
good stuff is in urm37.c.  This is for example purposes only.

It is just an example demonstrating how the resources needed by a
driver (FTI) can be statically initialized.

Other options are available - in the future calls (or upmctl) could be
used to query this array and allow changing certain items.

Currently, in the FTI descriptor struct, a list of upm_protocol_t's
are returned.  We could just pass this entire array via this
mechanism.  It would contain the same data, plus all of the specifics
(pin, bus, etc).

Signed-off-by: Jon Trulson jtrulson@ics.com
